### PR TITLE
Expand the user ID matching range for newer users

### DIFF
--- a/ddfastmail.py
+++ b/ddfastmail.py
@@ -37,7 +37,7 @@ class FastmailUpdater():
 				}
 
 		response = self.sess.post(FASTMAIL_URL, form, headers={'referer':FASTMAIL_URL})
-		result = re.search("&u=([0-9]*)&", response.content)
+		result = re.search("u=([0-9a-g]*)&", response.content)
 		if result is None:
 			raise ValueError("Could not find user_id! (Wrong username/password?)")
 		else:


### PR DESCRIPTION
My user ID has letters and numbers.  I don't know if Fastmail only uses hex in the ID now, or if they use all the alphabet, based on the difference between my ID and the current ddfastmail code.
When I dumped output I saw &amp;u= so I removed the match against the initial & too.
